### PR TITLE
fix: Remove csproj from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.user
 *.userosscache
 *.sln.docstates
-*.csproj
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
.csproj are the actual project files for each project and not the user specific IDE settings that is found in .csproj.user files